### PR TITLE
Avoid PackageError if 'python_versions' is missing.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,6 +147,9 @@ put it directly into ``pip``.
 Version History
 ===============
 
+0.4.1
+  * Fix PackageError if no Python version is defined.
+
 0.4
   * Add filtering of package releases by Python version.
 

--- a/hashin.py
+++ b/hashin.py
@@ -75,7 +75,7 @@ def run(spec, file, algorithm, python_versions=None, verbose=False):
     except KeyError:
         raise PackageError('No data found for version {0}'.format(version))
 
-    if python_versions is not None:
+    if python_versions:
         releases = filter_releases(releases, python_versions)
 
     if not releases:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if sys.version_info >= (2, 6) and sys.version_info <= (2, 7):
 
 setup(
     name='hashin',
-    version='0.4',
+    version='0.4.1',
     description='Edits your requirements.txt by hashing them in',
     long_description=open(path.join(_here, 'README.rst')).read(),
     author='Peter Bengtsson',


### PR DESCRIPTION
The default value of 'python_versions' is an empty list which has as a result that the `if python_versions is not None` check returns always true.