### PR TITLE
Make url metadata parsing compatible with new PyPI URLs

### DIFF
--- a/hashin.py
+++ b/hashin.py
@@ -173,8 +173,7 @@ def expand_python_version(version):
 # This should match the naming convention laid out in PEP 0427
 # url = 'https://pypi.python.org/packages/3.4/P/Pygments/Pygments-2.1-py3-none-any.whl'
 CLASSIFY_WHEEL_RE = re.compile('''
-    ^https://pypi.python.org/packages/[^/]+/[^/]/[^/]+/
-    (?P<package>.+)-
+    ^(?P<package>.+)-
     (?P<version>\d[^-]*)-
     (?P<python_version>[^-]+)-
     (?P<abi>[^-]+)-
@@ -185,8 +184,7 @@ CLASSIFY_WHEEL_RE = re.compile('''
 ''', re.VERBOSE)
 
 CLASSIFY_EGG_RE = re.compile('''
-    ^https://pypi.python.org/packages/[^/]+/[^/]/[^/]+/
-    (?P<package>.+)-
+    ^(?P<package>.+)-
     (?P<version>\d[^-]*)-
     (?P<python_version>[^-]+)
     (-(?P<platform>[^\.]+))?
@@ -196,8 +194,7 @@ CLASSIFY_EGG_RE = re.compile('''
 ''', re.VERBOSE)
 
 CLASSIFY_ARCHIVE_RE = re.compile('''
-    ^https://pypi.python.org/packages/[^/]+/[^/]/[^/]+/
-    (?P<package>.+)-
+    ^(?P<package>.+)-
     (?P<version>\d[^-]*)
     .(?P<format>tar.(gz|bz2)|zip)
     (\#md5=.*)?
@@ -205,8 +202,7 @@ CLASSIFY_ARCHIVE_RE = re.compile('''
 ''', re.VERBOSE)
 
 CLASSIFY_EXE_RE = re.compile('''
-    ^https://pypi.python.org/packages/[^/]+/[^/]/[^/]+/
-    (?P<package>.+)-
+    ^(?P<package>.+)-
     (?P<version>\d[^-]*)-
     ((?P<platform>[^-]*)-)?
     (?P<python_version>[^-]+)
@@ -217,6 +213,7 @@ CLASSIFY_EXE_RE = re.compile('''
 
 
 def release_url_metadata(url):
+    filename = url.split('/')[-1]
     defaults = {
         'package': None,
         'version': None,
@@ -227,12 +224,12 @@ def release_url_metadata(url):
     }
     simple_classifiers = [CLASSIFY_WHEEL_RE, CLASSIFY_EGG_RE, CLASSIFY_EXE_RE]
     for classifier in simple_classifiers:
-        match = classifier.match(url)
+        match = classifier.match(filename)
         if match:
             defaults.update(match.groupdict())
             return defaults
 
-    match = CLASSIFY_ARCHIVE_RE.match(url)
+    match = CLASSIFY_ARCHIVE_RE.match(filename)
     if match:
         defaults.update(match.groupdict())
         defaults['python_version'] = 'source'

--- a/tests.py
+++ b/tests.py
@@ -414,6 +414,15 @@ autocompeter==1.2.3  \\
             'platform': 'amd64',
             'format': 'exe',
         })
+        url = 'https://pypi.python.org/packages/d5/0d/445186a82bbcc75166a507eff586df683c73641e7d6bb7424a44426dca71/Django-1.8.12-py2.py3-none-any.whl'
+        self.assertEqual(hashin.release_url_metadata(url), {
+            'package': 'Django',
+            'version': '1.8.12',
+            'python_version': 'py2.py3',
+            'abi': 'none',
+            'platform': 'any',
+            'format': 'whl',
+        })
 
     def test_expand_python_version(self):
         self.assertEqual(sorted(hashin.expand_python_version('2.7')),


### PR DESCRIPTION
PyPI has added a new kind of URL, using the hash of the file as the directory path instead of a path based on the Python version and the package name. Luckily, we weren't using that information. I changed the URL analyzers to ignore the path in the URL, and only look at the filename. This should be more robust in the future: The filenames are standardized, the path is not.

@peterbe r?