### PR TITLE
Remove install_requires for python 2.6 compat

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,6 +147,10 @@ put it directly into ``pip``.
 Version History
 ===============
 
+0.6.0
+  * Fix compatibility issue with pip 8.1.2 and 8.1.1-2ubuntu0.1 and drop
+    support for Python 2.6
+
 0.5.0
   * Important bug fix. As an example, if you had ``pytest-selenium==...``
     already in your ``requirements.txt`` file and add ``selenium==x.y.z``

--- a/setup.py
+++ b/setup.py
@@ -12,17 +12,9 @@ try:
 except ImportError:
     pass
 
-install_requires = []
-
-if sys.version_info >= (2, 6) and sys.version_info <= (2, 7):
-    # Python 2.6 is the oldest version we support and it
-    # needs some extra stuff
-    install_requires.append('argparse')
-
-
 setup(
     name='hashin',
-    version='0.5.0',
+    version='0.6.0',
     description='Edits your requirements.txt by hashing them in',
     long_description=open(path.join(_here, 'README.rst')).read(),
     author='Peter Bengtsson',
@@ -34,15 +26,12 @@ setup(
         },
     url='https://github.com/peterbe/hashin',
     include_package_data=True,
-    install_requires=install_requires,
     tests_require=['nose>=1.3.0,<2.0', 'mock'],
     test_suite='nose.collector',
     classifiers=[
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Topic :: Software Development :: Build Tools',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{26,27,33,34,35}, lint
+envlist = py{27,33,34,35}, lint
 
 [testenv]
 commands = nosetests {posargs}


### PR DESCRIPTION
Remove support for Python 2.6 due to backwards incompatibility in
pip 8.1.2 (also affects 8.1.1-2ubuntu0.1)