### PR TITLE
Support msi packages

### DIFF
--- a/hashin.py
+++ b/hashin.py
@@ -205,7 +205,7 @@ CLASSIFY_EXE_RE = re.compile('''
     (?P<version>\d[^-]*)-
     ((?P<platform>[^-]*)-)?
     (?P<python_version>[^-]+)
-    .(?P<format>exe)
+    .(?P<format>(exe|msi))
     (\#md5=.*)?
     $
 ''', re.VERBOSE)


### PR DESCRIPTION
Sometimes packages can be bundled in the Microsoft Installer (msi)
format. For example:
https://pypi.python.org/pypi/Twisted/10.2.0