### PR TITLE
Allow multiple package specifiers at the same time

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,13 +77,22 @@ Or you can be specific about exactly which version you want::
 
     hashin "futures==2.1.3"
 
+You can also specify more than one package at a time::
+
+    hashin "futures==2.1.3" requests
+
 Suppose you don't have a ``requirements.txt`` right there in the same
-directory you can do this::
+directory you can specify ``--requirements-file``::
 
-    hashin "futures==2.1.3" stuff/requirementst/prod.txt
+    hashin futures --requirements-file=stuff/requirements/prod.txt
 
-If there's not output. It worked. Check how it edited your
-requirements files.
+By default sha256 hashes are used, but this can be overriden using the
+``--algorithm`` argument::
+
+    hashin futures --algorithm=sha512
+
+If there's no output, it worked. Check how it edited your
+requirements file.
 
 Filtering releases by Python version
 ====================================
@@ -112,8 +121,8 @@ these exact identifiers directly, if you need something specific.
 The ``source`` release is always automatically included. ``pip`` will use
 this as a fallback in the case a suitable wheel cannot be found.
 
-Runnings tests
-==============
+Running tests
+=============
 
 Simply run::
 

--- a/hashin.py
+++ b/hashin.py
@@ -55,7 +55,16 @@ def _download(url, binary=False):
     return r.read().decode(encoding)
 
 
-def run(spec, file, algorithm, python_versions=None, verbose=False):
+def run(specs, *args, **kwargs):
+    if isinstance(specs, str):
+        specs = [specs]
+
+    for spec in specs:
+        run_single_package(spec, *args, **kwargs)
+    return 0
+
+
+def run_single_package(spec, file, algorithm, python_versions=None, verbose=False):
     if '==' in spec:
         package, version = spec.split('==')
     else:
@@ -115,8 +124,6 @@ def run(spec, file, algorithm, python_versions=None, verbose=False):
     )
     with open(file, 'w') as f:
         f.write(requirements)
-
-    return 0
 
 
 def amend_requirements_content(requirements, package, new_lines):
@@ -284,36 +291,36 @@ def main():
     import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        'package',
-        help="package (e.g. some-package==1.2.3 or just some-package)"
+        'packages',
+        help="One or more package specifiers (e.g. some-package or some-package==1.2.3)",
+        nargs='+'
     )
     parser.add_argument(
-        'requirements_file',
+        '-r', '--requirements-file',
         help="requirements file to write to (default requirements.txt)",
-        default='requirements.txt', nargs='?'
+        default='requirements.txt'
     )
     parser.add_argument(
-        'algorithm',
+        '-a', '--algorithm',
         help="The hash algorithm to use: one of sha256, sha384, sha512",
-        default='sha256', nargs='?'
+        default='sha256'
     )
     parser.add_argument(
-        "-v, --verbose",
+        '-v', '--verbose',
         help="Verbose output",
         action="store_true",
-        dest='verbose',
     )
     parser.add_argument(
-        '-p, --python-version',
+        '-p', '--python-version',
         help='Python version to add wheels for. May be used multiple times.',
         action='append',
         default=[],
-        dest='python_version',
     )
 
     args = parser.parse_args()
+
     return run(
-        args.package,
+        args.packages,
         args.requirements_file,
         args.algorithm,
         args.python_version,


### PR DESCRIPTION
This allows e.g:
    $ hashin packageA==1.2.3 packageB==2.3.4 packageC

This change means that 'requirements_file' and 'algorithm' can
no longer be positional arguments, so -r/--requirements-file and
-a/--algorithm were added for them respectively. Obviously this
breaks backwards compat.

This is also the simplest way to implement it, but not necessarily
the most efficient. For example, this will open/close the requirements
file each time, rather than leaving it open for the duration.