### PR TITLE
figure out latest release version minus pre releases

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -185,6 +185,11 @@ put it directly into ``pip``.
 Version History
 ===============
 
+0.10.0
+  * Latest version is now figured out by looking at all version numbers
+    in the list of releases from the JSON payload. The pre releases are
+    skipped.
+
 0.9.0
   * Fixed a bug where it would fail to install a package whose name is
     partially part of an existing (installed) package.

--- a/hashin.py
+++ b/hashin.py
@@ -14,7 +14,7 @@ import json
 from itertools import chain
 
 import pip
-from pip._vendor.distlib.version import NormalizedVersion
+from pip._vendor.packaging.version import parse
 
 if sys.version_info >= (3,):
     from urllib.request import urlopen
@@ -184,16 +184,12 @@ def get_latest_version(data):
         return data['info']['version']
     all_versions = []
     for version in data['releases']:
-        v = NormalizedVersion(version)
+        v = parse(version)
         if not v.is_prerelease:
-            # Remember, the normalized (i.e. parsed) version
-            # and the original version string as it's called in the
-            # data blob. We do this so we can sort all versions.
-            all_versions.append((v, version))
+            all_versions.append(v)
     all_versions.sort(reverse=True)
-    # Return the original version string of the highest version
-    # number when normalized.
-    return all_versions[0][1]
+    # return the highest non-pre-release version
+    return str(all_versions[0])
 
 
 def expand_python_version(version):

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,13 @@ _here = path.dirname(__file__)
 # http://www.eby-sarna.com/pipermail/peak/2010-May/003357.html:
 try:
     import multiprocessing
-    multiprocessing = multiprocessing  # shut up pyflakes
+    multiprocessing = multiprocessing  # take it easy pyflakes
 except ImportError:
     pass
 
 setup(
     name='hashin',
-    version='0.9.0',
+    version='0.10.0',
     description='Edits your requirements.txt by hashing them in',
     long_description=open(path.join(_here, 'README.rst')).read(),
     author='Peter Bengtsson',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,6 +74,24 @@ class Tests(TestCase):
         self.assertEqual(version, '0.3')
 
     @mock.patch('hashin.urlopen')
+    def test_get_latest_version_non_pre_release(self, murlopen):
+        version = hashin.get_latest_version({
+            'info': {
+                'version': '0.3',
+            },
+            'releases': {
+                '0.99': {},
+                '0.999': {},
+                '1.1.0rc1': {},
+                '1.1rc1': {},
+                '1.0a1': {},
+                '2.0b2': {},
+                '2.0c3': {},
+            }
+        })
+        self.assertEqual(version, '0.999')
+
+    @mock.patch('hashin.urlopen')
     def test_get_hashes_error(self, murlopen):
 
         def mocked_get(url, **options):


### PR DESCRIPTION
Would love some eyes on this @mythmon @sesh @jezdez

It works for me. Now when I do `hashin Django` it installs `1.10.6` and not `1.11rc1`.