### PR TITLE
Use pip-api instead of pip's internal APIs

### DIFF
--- a/hashin.py
+++ b/hashin.py
@@ -13,7 +13,7 @@ import sys
 import json
 from itertools import chain
 
-import pip
+import pip_api
 from packaging.version import parse
 
 if sys.version_info >= (3,):
@@ -72,7 +72,7 @@ parser.add_argument(
 )
 
 
-major_pip_version = int(pip.__version__.split('.')[0])
+major_pip_version = int(pip_api.version().split('.')[0])
 if major_pip_version < 8:
     raise ImportError(
         'hashin only works with pip 8.x or greater'
@@ -363,7 +363,7 @@ def get_releases_hashes(releases, algorithm, verbose=False):
             elif verbose:
                 _verbose('  Re-using', filename)
 
-            found['hash'] = pip.commands.hash._hash_of_file(filename, algorithm)
+            found['hash'] = pip_api.hash(filename, algorithm)
         if verbose:
             _verbose('  Hash', found['hash'])
         yield {

--- a/hashin.py
+++ b/hashin.py
@@ -14,7 +14,7 @@ import json
 from itertools import chain
 
 import pip
-from pip._vendor.packaging.version import parse
+from packaging.version import parse
 
 if sys.version_info >= (3,):
     from urllib.request import urlopen

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         },
     url='https://github.com/peterbe/hashin',
     include_package_data=True,
+    python_requires='>=2.7,!=3.0,!=3.1,!=3.2,!=3.3',
     install_requires=['packaging', 'pip-api'],
     tests_require=['pytest', 'mock'],
     setup_requires=['pytest-runner'],

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         },
     url='https://github.com/peterbe/hashin',
     include_package_data=True,
-    install_requires=['packaging'],
+    install_requires=['packaging', 'pip-api'],
     tests_require=['pytest', 'mock'],
     setup_requires=['pytest-runner'],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         },
     url='https://github.com/peterbe/hashin',
     include_package_data=True,
+    install_requires=['packaging'],
     tests_require=['pytest', 'mock'],
     setup_requires=['pytest-runner'],
     classifiers=[


### PR DESCRIPTION
Fixes #58.

Instead of using `pip`'s internal APIs, which will be moving in `pip==10.0.0`, use [`pip-api`](https://pypi.org/project/pip-api/) instead.

Also switches to using the `packaging` project directly, rather than `pip` vendored version of it (I didn't see why this would be necessary).