### PR TITLE
match python versions that have major/minor with no dot

### DIFF
--- a/hashin.py
+++ b/hashin.py
@@ -261,6 +261,7 @@ def expand_python_version(version):
         'cp{major}{minor}',
         'py{major}',
         'py{major}.{minor}',
+        'py{major}{minor}',
         'source',
         'py2.py3',
     ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -923,9 +923,9 @@ selenium==2.53.1 \
 
     def test_expand_python_version(self):
         self.assertEqual(sorted(hashin.expand_python_version('2.7')),
-                         ['2.7', 'cp27', 'py2', 'py2.7', 'py2.py3', 'source'])
+                         ['2.7', 'cp27', 'py2', 'py2.7', 'py2.py3', 'py27', 'source'])
         self.assertEqual(sorted(hashin.expand_python_version('3.5')),
-                         ['3.5', 'cp35', 'py2.py3', 'py3', 'py3.5', 'source'])
+                         ['3.5', 'cp35', 'py2.py3', 'py3', 'py3.5', 'py35', 'source'])
 
     @cleanup_tmpdir('hashin*')
     @mock.patch('hashin.urlopen')


### PR DESCRIPTION
Some filenames have the version of `py{major}{minor}` (i.e. with no dot).

For example: https://pypi.org/project/Paste/#files has `Paste-2.0.3-py34-none-any.whl` causes the classifier to generate `py34` for the `python_version`, but when using the `--python-version=3.4" argument, it would only match `['cp34', 'source', 'py2.py3', 'py3', 'py3.4', '3.4']`.

The PR adds `py{major}{minor}` as a valid expanded python version.
