### PR TITLE
Update CLASSIFY_EXE_RE to parse ntlk win package

### DIFF
--- a/hashin.py
+++ b/hashin.py
@@ -304,7 +304,7 @@ CLASSIFY_ARCHIVE_RE = re.compile('''
 
 CLASSIFY_EXE_RE = re.compile('''
     ^(?P<package>.+)-
-    (?P<version>\d[^-]*)-
+    (?P<version>\d[^-]*)[-\.]
     ((?P<platform>[^-]*)-)?
     (?P<python_version>[^-]+)
     .(?P<format>(exe|msi))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -892,6 +892,15 @@ selenium==2.53.1 \
             'platform': None,
             'format': 'egg',
         })
+        url = 'https://files.pythonhosted.org/packages/26/01/0330e3ba13628827f10fcd6c3c8d778a5aa3e4d0a09d05619f074ba2d87e/nltk-3.2.4.win32.exe'
+        self.assertEqual(hashin.release_url_metadata(url), {
+            'package': 'nltk',
+            'version': '3.2.4',
+            'python_version': mock.ANY,
+            'abi': None,
+            'platform': None,
+            'format': 'exe',
+        })
         url = 'https://pypi.org/packages/2.7/g/gevent/gevent-1.1.0.win-amd64-py2.7.exe'
         self.assertEqual(hashin.release_url_metadata(url), {
             'package': 'gevent',


### PR DESCRIPTION
If you specify a python version, then hashin filters the releases but can't parse the win binary for the nltk package.

```
hashin --python-version 3.6 nltk==3.2.4
https://pypi.org/pypi/nltk/json
Unrecognizable url: https://files.pythonhosted.org/packages/26/01/0330e3ba13628827f10fcd6c3c8d778a5aa3e4d0a09d05619f074ba2d87e/nltk-3.2.4.win32.exe
```