### PR TITLE
63 update all

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -254,6 +254,10 @@ Version History
 
 next
 
+  * New flag ``--update-all`` (alias ``-u``) will parse the requirements file,
+    ignore the version, and update all packages that have new versions.
+    See https://github.com/peterbe/hashin/pull/88
+
   * Support for "extras syntax". E.g. ``hashin "requests[security]"``. Doesn't
     actually get hashes for ``security`` (in this case, that's not even a
     package) but allows that syntax into your ``requirements.txt`` file.

--- a/tests/test_arg_parse.py
+++ b/tests/test_arg_parse.py
@@ -27,6 +27,7 @@ def test_everything():
         version=False,
         include_prereleases=False,
         dry_run=True,
+        update_all=False,
     )
     assert args == (expected, [])
 
@@ -55,6 +56,7 @@ def test_everything_long():
         version=False,
         include_prereleases=False,
         dry_run=True,
+        update_all=False,
     )
     assert args == (expected, [])
 
@@ -70,5 +72,6 @@ def test_minimal():
         version=False,
         include_prereleases=False,
         dry_run=False,
+        update_all=False,
     )
     assert args == (expected, [])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,8 @@ if sys.version_info >= (3,):
 else:  # Python 2
     from StringIO import StringIO
 
+    FileNotFoundError = IOError  # ugly but necessary
+
 
 @contextmanager
 def redirect_stdout(stream):
@@ -664,18 +666,6 @@ selenium==2.53.1 \
         inside the PyPI data."""
 
         def mocked_get(url, **options):
-            # if url == "https://pypi.org/pypi/HASHin/json":
-            #     return _Response(
-            #         "",
-            #         status_code=301,
-            #         headers={"location": "https://pypi.org/pypi/hashin/json"},
-            #     )
-            # elif url == "https://pypi.org/pypi/hashIN/json":
-            #     return _Response(
-            #         "",
-            #         status_code=301,
-            #         headers={"location": "https://pypi.org/pypi/hashin/json"},
-            #     )
             if url == "https://pypi.org/pypi/hashin/json":
                 return _Response(
                     {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import argparse
 import sys
 import json
 import os
@@ -187,10 +188,70 @@ class Tests(TestCase):
         # Doesn't matter so much what, just make sure it breaks
         mock_run.side_effect = hashin.PackageError("Some message here")
 
+        def mock_parse_args(*a, **k):
+            return argparse.Namespace(
+                packages=["something"],
+                requirements_file="requirements.txt",
+                algorithm="sha256",
+                python_version="3.8",
+                verbose=False,
+                include_prereleases=False,
+                dry_run=False,
+                update_all=False,
+            )
+
+        mock_parser.parse_args.side_effect = mock_parse_args
+
         error = hashin.main()
         self.assertEqual(error, 1)
         mock_sys.stderr.write.assert_any_call("Some message here")
         mock_sys.stderr.write.assert_any_call("\n")
+
+    @mock.patch("hashin.parser")
+    @mock.patch("hashin.sys")
+    def test_packages_and_update_all(self, mock_sys, mock_parser):
+        def mock_parse_args(*a, **k):
+            return argparse.Namespace(
+                packages=["something"],
+                requirements_file="requirements.txt",
+                algorithm="sha256",
+                python_version="3.8",
+                verbose=False,
+                include_prereleases=False,
+                dry_run=False,
+                update_all=True,  # Note!
+            )
+
+        mock_parser.parse_args.side_effect = mock_parse_args
+
+        error = hashin.main()
+        self.assertEqual(error, 2)
+        mock_sys.stderr.write.assert_any_call(
+            "Can not combine the --update-all option with a list of packages."
+        )
+
+    @mock.patch("hashin.parser")
+    @mock.patch("hashin.sys")
+    def test_no_packages_and_not_update_all(self, mock_sys, mock_parser):
+        def mock_parse_args(*a, **k):
+            return argparse.Namespace(
+                packages=[],  # Note!
+                requirements_file="requirements.txt",
+                algorithm="sha256",
+                python_version="3.8",
+                verbose=False,
+                include_prereleases=False,
+                dry_run=False,
+                update_all=False,
+            )
+
+        mock_parser.parse_args.side_effect = mock_parse_args
+
+        error = hashin.main()
+        self.assertEqual(error, 3)
+        mock_sys.stderr.write.assert_any_call(
+            "If you don't use --update-all you must list packages."
+        )
 
     @mock.patch("hashin.sys")
     def test_main_version(self, mock_sys):
@@ -601,6 +662,190 @@ selenium==2.53.1 \
         """No matter how you run the cli with a package's case typing,
         it should find it and correct the cast typing per what it is
         inside the PyPI data."""
+
+        def mocked_get(url, **options):
+            # if url == "https://pypi.org/pypi/HASHin/json":
+            #     return _Response(
+            #         "",
+            #         status_code=301,
+            #         headers={"location": "https://pypi.org/pypi/hashin/json"},
+            #     )
+            # elif url == "https://pypi.org/pypi/hashIN/json":
+            #     return _Response(
+            #         "",
+            #         status_code=301,
+            #         headers={"location": "https://pypi.org/pypi/hashin/json"},
+            #     )
+            if url == "https://pypi.org/pypi/hashin/json":
+                return _Response(
+                    {
+                        "info": {"version": "0.11", "name": "hashin"},
+                        "releases": {
+                            "0.11": [
+                                {
+                                    "url": "https://pypi.org/packages/source/p/hashin/hashin-0.11.tar.gz",
+                                    "digests": {"sha256": "bbbbb"},
+                                }
+                            ],
+                            "0.10": [
+                                {
+                                    "url": "https://pypi.org/packages/source/p/hashin/hashin-0.10.tar.gz",
+                                    "digests": {"sha256": "aaaaa"},
+                                }
+                            ],
+                        },
+                    }
+                )
+            elif url == "https://pypi.org/pypi/hashin/json":
+                return _Response(
+                    {
+                        "info": {"version": "0.11", "name": "hashin"},
+                        "releases": {
+                            "0.11": [
+                                {
+                                    "url": "https://pypi.org/packages/source/p/hashin/hashin-0.11.tar.gz",
+                                    "digests": {"sha256": "bbbbb"},
+                                }
+                            ],
+                            "0.10": [
+                                {
+                                    "url": "https://pypi.org/packages/source/p/hashin/hashin-0.10.tar.gz",
+                                    "digests": {"sha256": "aaaaa"},
+                                }
+                            ],
+                        },
+                    }
+                )
+            elif url == "https://pypi.org/pypi/requests/json":
+                return _Response(
+                    {
+                        "info": {"version": "1.2.4", "name": "requests"},
+                        "releases": {
+                            "1.2.4": [
+                                {
+                                    "url": "https://pypi.org/packages/source/p/requests/requests-1.2.4.tar.gz",
+                                    "digests": {"sha256": "dededede"},
+                                }
+                            ]
+                        },
+                    }
+                )
+            if url == "https://pypi.org/pypi/enum34/json":
+                return _Response(
+                    {
+                        "info": {"version": "1.1.6", "name": "enum34"},
+                        "releases": {
+                            "1.1.6": [
+                                {
+                                    "has_sig": False,
+                                    "upload_time": "2016-05-16T03:31:13",
+                                    "comment_text": "",
+                                    "python_version": "py2",
+                                    "url": "https://pypi.org/packages/c5/db/enum34-1.1.6-py2-none-any.whl",
+                                    "digests": {
+                                        "md5": "68f6982cc07dde78f4b500db829860bd",
+                                        "sha256": "aaaaa",
+                                    },
+                                    "md5_digest": "68f6982cc07dde78f4b500db829860bd",
+                                    "downloads": 4297423,
+                                    "filename": "enum34-1.1.6-py2-none-any.whl",
+                                    "packagetype": "bdist_wheel",
+                                    "path": "c5/db/enum34-1.1.6-py2-none-any.whl",
+                                    "size": 12427,
+                                },
+                                {
+                                    "has_sig": False,
+                                    "upload_time": "2016-05-16T03:31:19",
+                                    "comment_text": "",
+                                    "python_version": "py3",
+                                    "url": "https://pypi.org/packages/af/42/enum34-1.1.6-py3-none-any.whl",
+                                    "md5_digest": "a63ecb4f0b1b85fb69be64bdea999b43",
+                                    "digests": {
+                                        "md5": "a63ecb4f0b1b85fb69be64bdea999b43",
+                                        "sha256": "bbbbb",
+                                    },
+                                    "downloads": 98598,
+                                    "filename": "enum34-1.1.6-py3-none-any.whl",
+                                    "packagetype": "bdist_wheel",
+                                    "path": "af/42/enum34-1.1.6-py3-none-any.whl",
+                                    "size": 12428,
+                                },
+                                {
+                                    "has_sig": False,
+                                    "upload_time": "2016-05-16T03:31:30",
+                                    "comment_text": "",
+                                    "python_version": "source",
+                                    "url": "https://pypi.org/packages/bf/3e/enum34-1.1.6.tar.gz",
+                                    "md5_digest": "5f13a0841a61f7fc295c514490d120d0",
+                                    "digests": {
+                                        "md5": "5f13a0841a61f7fc295c514490d120d0",
+                                        "sha256": "ccccc",
+                                    },
+                                    "downloads": 188090,
+                                    "filename": "enum34-1.1.6.tar.gz",
+                                    "packagetype": "sdist",
+                                    "path": "bf/3e/enum34-1.1.6.tar.gz",
+                                    "size": 40048,
+                                },
+                                {
+                                    "has_sig": False,
+                                    "upload_time": "2016-05-16T03:31:48",
+                                    "comment_text": "",
+                                    "python_version": "source",
+                                    "url": "https://pypi.org/packages/e8/26/enum34-1.1.6.zip",
+                                    "md5_digest": "61ad7871532d4ce2d77fac2579237a9e",
+                                    "digests": {
+                                        "md5": "61ad7871532d4ce2d77fac2579237a9e",
+                                        "sha256": "dddddd",
+                                    },
+                                    "downloads": 775920,
+                                    "filename": "enum34-1.1.6.zip",
+                                    "packagetype": "sdist",
+                                    "path": "e8/26/enum34-1.1.6.zip",
+                                    "size": 44773,
+                                },
+                            ]
+                        },
+                    }
+                )
+
+            raise NotImplementedError(url)
+
+        murlopen.side_effect = mocked_get
+
+        with tmpfile() as filename:
+            with self.assertRaises(FileNotFoundError):
+                retcode = hashin.run(None, filename, "sha256")
+
+            with open(filename, "w") as f:
+                f.write("# This is comment. Ignore this.\n")
+                f.write("\n")
+                f.write("requests[security]==1.2.3 \\\n")
+                f.write("    --hash=sha256:99dcfdaae\n")
+                f.write("hashin==0.11 \\\n")
+                f.write("    --hash=sha256:a84b8c9ab623\n")
+                f.write("enum34==1.1.5; python_version <= '3.4' \\\n")
+                f.write("    --hash=sha256:12ce5c2ef718\n")
+                f.write("\n")
+
+            retcode = hashin.run(None, filename, "sha256", verbose=True)
+
+            self.assertEqual(retcode, 0)
+            with open(filename) as f:
+                output = f.read()
+
+            self.assertTrue("requests[security]==1.2.3" not in output)
+            self.assertTrue("requests[security]==1.2.4" in output)
+            # This one didn't need to be updated.
+            self.assertTrue("hashin==0.11" in output)
+            self.assertTrue('enum34==1.1.5; python_version <= "3.4"' not in output)
+            self.assertTrue('enum34==1.1.6; python_version <= "3.4"' in output)
+
+    @cleanup_tmpdir("hashin*")
+    @mock.patch("hashin.urlopen")
+    def test_run_update_all(self, murlopen):
+        """The --update-all flag will extra all the names from the existing
+        requirements file, and check with pypi.org if there's a new version."""
 
         def mocked_get(url, **options):
             if url == "https://pypi.org/pypi/HAShin/json":


### PR DESCRIPTION
Fixes #63

The challenge here is whether to call it **"update"** or **"upgrade"**. 
The truth is that `hashin` doesn't upgrade any packages, it just updates the requirements. 

I created a requirements file with some packages I know are "updateable". 

```
▶ python hashin.py -r /tmp/reqs.txt -u --dry-run

--- Old
+++ New
@@ -1,9 +1,9 @@
 requests[security]==2.20.0 \
     --hash=sha256:99dcfdaaeb17caf6e526f32b6a7b780461512ab3f1d992187801694cba42770c \
     --hash=sha256:a84b8c9ab6239b578f22d1c21d51b696dcfe004032bb80ea832398d6909d7279
-kinto-attachment==5.0.0 \
-    --hash=sha256:4444e3c225d30cecdd5abd59afc9cc3b2412045b8b515a73e5b81a89638f3243 \
-    --hash=sha256:c54fd4d8a40498218c7b78f61fc5ce3eedead00a441af58fc12a12644e64410c
+kinto-attachment==6.0.0 \
+    --hash=sha256:12ce5c2ef718e7e31cef2e2a3bde771d9216f2cb014efba963e69cb709bcbbd1 \
+    --hash=sha256:fd54e979d3747be638f59de44a7f6523bed56d81961a438462b1346f49be5fe4
 boto3==1.9.16 \
     --hash=sha256:7d2ae0a759ede09474387dae246d8fe9c1f07e98fa3366ebffd0536571558261 \
     --hash=sha256:abc08c826c0628cb22fee2a2a5a21bad6a7f261042c652e4f994f376333cf52c

--- Old
+++ New
@@ -4,9 +4,9 @@
 kinto-attachment==5.0.0 \
     --hash=sha256:4444e3c225d30cecdd5abd59afc9cc3b2412045b8b515a73e5b81a89638f3243 \
     --hash=sha256:c54fd4d8a40498218c7b78f61fc5ce3eedead00a441af58fc12a12644e64410c
-boto3==1.9.16 \
-    --hash=sha256:7d2ae0a759ede09474387dae246d8fe9c1f07e98fa3366ebffd0536571558261 \
-    --hash=sha256:abc08c826c0628cb22fee2a2a5a21bad6a7f261042c652e4f994f376333cf52c
+boto3==1.9.31 \
+    --hash=sha256:03bdbd5bfc8c9f603877edf208a947b9e9d3d29268e3c3c46c3a8ee3d64ccda8 \
+    --hash=sha256:bc7b8e65b9612ee7ff03f71e765d0f380c8db096d898213bb4ead5b389c31cde
 botocore==1.12.31 \
     --hash=sha256:409edb0651313a04e93f2bfff2663ef84f742034f2099478d07b0c508b921c02 \
     --hash=sha256:dea459bfa0418689f2dfd8241739e7bb071d1cc944ffcc9cce0c19ecaf3612f3


```

This time, without the `-u` shortcut but with the full `--update-all`:
```
▶ python hashin.py -r /tmp/reqs.txt --update-all
▶ diff /tmp/reqs.txt /tmp/reqs.txt.backup
4,9c4,9
< kinto-attachment==6.0.0 \
<     --hash=sha256:12ce5c2ef718e7e31cef2e2a3bde771d9216f2cb014efba963e69cb709bcbbd1 \
<     --hash=sha256:fd54e979d3747be638f59de44a7f6523bed56d81961a438462b1346f49be5fe4
< boto3==1.9.31 \
<     --hash=sha256:03bdbd5bfc8c9f603877edf208a947b9e9d3d29268e3c3c46c3a8ee3d64ccda8 \
<     --hash=sha256:bc7b8e65b9612ee7ff03f71e765d0f380c8db096d898213bb4ead5b389c31cde
---
> kinto-attachment==5.0.0 \
>     --hash=sha256:4444e3c225d30cecdd5abd59afc9cc3b2412045b8b515a73e5b81a89638f3243 \
>     --hash=sha256:c54fd4d8a40498218c7b78f61fc5ce3eedead00a441af58fc12a12644e64410c
> boto3==1.9.16 \
>     --hash=sha256:7d2ae0a759ede09474387dae246d8fe9c1f07e98fa3366ebffd0536571558261 \
>     --hash=sha256:abc08c826c0628cb22fee2a2a5a21bad6a7f261042c652e4f994f376333cf52c
```
