### PR TITLE
Add an optional --index-url argument similar to that in pip

### DIFF
--- a/hashin.py
+++ b/hashin.py
@@ -753,7 +753,7 @@ def get_parser():
     )
     parser.add_argument(
         "--index-url",
-        help="alternate package index url (default https://pypi.org/)",
+        help="alternate package index url (default {0})".format(DEFAULT_INDEX_URL),
         default=None,
     )
     return parser

--- a/hashin.py
+++ b/hashin.py
@@ -741,6 +741,11 @@ def get_parser():
         action="store_true",
         default=False,
     )
+    parser.add_argument(
+        "--index-url",
+        help="package index url (default https://pypi.org/)",
+        default="https://pypi.org/",
+    )
     return parser
 
 

--- a/hashin.py
+++ b/hashin.py
@@ -164,7 +164,9 @@ def run_packages(
 
     lookup_memory = {}
     if not synchronous and len(specs) > 1:
-        pre_download_packages(lookup_memory, specs, verbose=verbose, index_url=index_url)
+        pre_download_packages(
+            lookup_memory, specs, verbose=verbose, index_url=index_url
+        )
 
     for spec in specs:
         package, version, restriction = _explode_package_spec(spec)
@@ -284,7 +286,9 @@ def pre_download_packages(memory, specs, verbose=False, index_url=None):
             package, _, _ = _explode_package_spec(spec)
             req = Requirement(package)
             futures[
-                executor.submit(get_package_data, req.name, verbose=verbose, index_url=index_url)
+                executor.submit(
+                    get_package_data, req.name, verbose=verbose, index_url=index_url
+                )
             ] = req.name
         for future in concurrent.futures.as_completed(futures):
             content = future.result()

--- a/hashin.py
+++ b/hashin.py
@@ -25,8 +25,10 @@ from packaging.version import parse
 if sys.version_info >= (3,):
     from urllib.request import urlopen
     from urllib.error import HTTPError
+    from urllib.parse import urljoin
 else:
     from urllib import urlopen
+    from urlparse import urljoin
 
     input = raw_input  # noqa
 
@@ -153,6 +155,7 @@ def run_packages(
     previous_versions=None,
     interactive=False,
     synchronous=False,
+    index_url=None,
 ):
     assert isinstance(specs, list), type(specs)
     all_new_lines = []
@@ -161,7 +164,7 @@ def run_packages(
 
     lookup_memory = {}
     if not synchronous and len(specs) > 1:
-        pre_download_packages(lookup_memory, specs, verbose=verbose)
+        pre_download_packages(lookup_memory, specs, verbose=verbose, index_url=index_url)
 
     for spec in specs:
         package, version, restriction = _explode_package_spec(spec)
@@ -186,6 +189,7 @@ def run_packages(
             algorithm=algorithm,
             include_prereleases=include_prereleases,
             lookup_memory=lookup_memory,
+            index_url=index_url,
         )
         package = data["package"]
         # We need to keep this `req` instance for the sake of turning it into a string
@@ -273,14 +277,14 @@ def run_packages(
     return 0
 
 
-def pre_download_packages(memory, specs, verbose=False):
+def pre_download_packages(memory, specs, verbose=False, index_url=None):
     futures = {}
     with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
         for spec in specs:
             package, _, _ = _explode_package_spec(spec)
             req = Requirement(package)
             futures[
-                executor.submit(get_package_data, req.name, verbose=verbose)
+                executor.submit(get_package_data, req.name, verbose=verbose, index_url=index_url)
             ] = req.name
         for future in concurrent.futures.as_completed(futures):
             content = future.result()
@@ -567,8 +571,9 @@ def filter_releases(releases, python_versions):
     return filtered
 
 
-def get_package_data(package, verbose=False):
-    url = "https://pypi.org/pypi/%s/json" % package
+def get_package_data(package, verbose=False, index_url=None):
+    path = "/pypi/%s/json" % package
+    url = urljoin(index_url, path)
     if verbose:
         print(url)
     content = json.loads(_download(url))
@@ -615,6 +620,7 @@ def get_package_hashes(
     verbose=False,
     include_prereleases=False,
     lookup_memory=None,
+    index_url=None,
 ):
     """
     Gets the hashes for the given package.
@@ -642,7 +648,7 @@ def get_package_hashes(
     if lookup_memory is not None and package in lookup_memory:
         data = lookup_memory[package]
     else:
-        data = get_package_data(package, verbose)
+        data = get_package_data(package, verbose, index_url=index_url)
     if not version:
         version = get_latest_version(data, include_prereleases)
         assert version
@@ -791,6 +797,7 @@ def main():
             dry_run=args.dry_run,
             interactive=args.interactive,
             synchronous=args.synchronous,
+            index_url=args.index_url,
         )
     except PackageError as exception:
         print(str(exception), file=sys.stderr)

--- a/tests/test_arg_parse.py
+++ b/tests/test_arg_parse.py
@@ -85,6 +85,6 @@ def test_minimal():
         update_all=False,
         interactive=False,
         synchronous=False,
-        index_url="https://pypi.org/",
+        index_url=None,
     )
     assert args == (expected, [])

--- a/tests/test_arg_parse.py
+++ b/tests/test_arg_parse.py
@@ -16,6 +16,8 @@ def test_everything():
             "3.5",
             "-v",
             "--dry-run",
+            "--index-url",
+            "https://pypi1.someorg.net/",
         ]
     )
     expected = argparse.Namespace(
@@ -30,6 +32,7 @@ def test_everything():
         update_all=False,
         interactive=False,
         synchronous=False,
+        index_url="https://pypi1.someorg.net/",
     )
     assert args == (expected, [])
 
@@ -47,6 +50,8 @@ def test_everything_long():
             "3.5",
             "--verbose",
             "--dry-run",
+            "--index-url",
+            "https://pypi1.someorg.net/",
         ]
     )
     expected = argparse.Namespace(
@@ -61,6 +66,7 @@ def test_everything_long():
         update_all=False,
         interactive=False,
         synchronous=False,
+        index_url="https://pypi1.someorg.net/",
     )
     assert args == (expected, [])
 
@@ -79,5 +85,6 @@ def test_minimal():
         update_all=False,
         interactive=False,
         synchronous=False,
+        index_url="https://pypi.org/",
     )
     assert args == (expected, [])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -117,7 +117,12 @@ def test_get_hashes_error(murlopen):
 
     murlopen.side_effect = mocked_get
     with pytest.raises(hashin.PackageError):
-        hashin.run("somepackage==1.2.3", "doesntmatter.txt", "sha256", index_url="https://pypi.org/")
+        hashin.run(
+            "somepackage==1.2.3",
+            "doesntmatter.txt",
+            "sha256",
+            index_url="https://pypi.org/",
+        )
 
 
 def test_non_200_ok_download(murlopen):
@@ -127,7 +132,12 @@ def test_non_200_ok_download(murlopen):
     murlopen.side_effect = mocked_get
 
     with pytest.raises(hashin.PackageError):
-        hashin.run("somepackage==1.2.3", "doesntmatter.txt", "sha256", index_url="https://pypi.org/")
+        hashin.run(
+            "somepackage==1.2.3",
+            "doesntmatter.txt",
+            "sha256",
+            index_url="https://pypi.org/",
+        )
 
 
 def test_main_packageerrors_stderr(mock_run, capsys, mock_get_parser):
@@ -592,7 +602,13 @@ def test_run(murlopen, tmpfile, capsys):
         with open(filename, "w") as f:
             f.write("")
 
-        retcode = hashin.run("hashin==0.10", filename, "sha256", verbose=True, index_url="https://pypi.org/")
+        retcode = hashin.run(
+            "hashin==0.10",
+            filename,
+            "sha256",
+            verbose=True,
+            index_url="https://pypi.org/",
+        )
 
         assert retcode == 0
         with open(filename) as f:
@@ -623,7 +639,9 @@ def test_run(murlopen, tmpfile, capsys):
         assert "aaaaa" in out_lines[2], out_lines[2]
 
         # Change algorithm
-        retcode = hashin.run("hashin==0.10", filename, "sha512", index_url="https://pypi.org/")
+        retcode = hashin.run(
+            "hashin==0.10", filename, "sha512", index_url="https://pypi.org/"
+        )
         assert retcode == 0
         with open(filename) as f:
             output = f.read()
@@ -688,7 +706,13 @@ def test_run_atomic_not_write_with_error_on_last_package(murlopen, tmpfile):
             f.write("")
 
         with pytest.raises(hashin.PackageNotFoundError):
-            hashin.run(["hashin", "gobblygook"], filename, "sha256", verbose=True, index_url="https://pypi.org/")
+            hashin.run(
+                ["hashin", "gobblygook"],
+                filename,
+                "sha256",
+                verbose=True,
+                index_url="https://pypi.org/",
+            )
 
         with open(filename) as f:
             output = f.read()
@@ -840,7 +864,13 @@ enum34==1.1.5; python_version <= '3.4' \\
 
         # Basically means we're saying "No" to all of them.
         with mock.patch("hashin.input", return_value="N"):
-            retcode = hashin.run(None, filename, "sha256", interactive=True, index_url="https://pypi.org/")
+            retcode = hashin.run(
+                None,
+                filename,
+                "sha256",
+                interactive=True,
+                index_url="https://pypi.org/",
+            )
         assert retcode == 0
 
         with open(filename) as f:
@@ -861,7 +891,13 @@ enum34==1.1.5; python_version <= '3.4' \\
 
         with mock.patch("hashin.input") as mocked_input:
             mocked_input.side_effect = mock_input
-            retcode = hashin.run(None, filename, "sha256", interactive=True, index_url="https://pypi.org/")
+            retcode = hashin.run(
+                None,
+                filename,
+                "sha256",
+                interactive=True,
+                index_url="https://pypi.org/",
+            )
         assert retcode == 0
 
         # The expected output is that only "requests[security]" and "enum34"
@@ -1039,7 +1075,13 @@ enum34==1.1.5; python_version <= '3.4' \\
 
         with mock.patch("hashin.input") as mocked_input:
             mocked_input.side_effect = mock_input
-            retcode = hashin.run(None, filename, "sha256", interactive=True, index_url="https://pypi.org/")
+            retcode = hashin.run(
+                None,
+                filename,
+                "sha256",
+                interactive=True,
+                index_url="https://pypi.org/",
+            )
         assert retcode != 0
         assert len(questions) == 1
 
@@ -1049,7 +1091,13 @@ enum34==1.1.5; python_version <= '3.4' \\
 
         with mock.patch("hashin.input") as mocked_input:
             mocked_input.side_effect = mock_input
-            retcode = hashin.run(None, filename, "sha256", interactive=True, index_url="https://pypi.org/")
+            retcode = hashin.run(
+                None,
+                filename,
+                "sha256",
+                interactive=True,
+                index_url="https://pypi.org/",
+            )
         assert retcode == 0
 
         # The expected output is that only "requests[security]" and "enum34"
@@ -1158,7 +1206,13 @@ Hash-in==0.9 \\
             assert output == before
 
         with mock.patch("hashin.input", return_value="Y"):
-            retcode = hashin.run(None, filename, "sha256", interactive=True, index_url="https://pypi.org/")
+            retcode = hashin.run(
+                None,
+                filename,
+                "sha256",
+                interactive=True,
+                index_url="https://pypi.org/",
+            )
         assert retcode == 0
 
         # The expected output is that only "requests[security]" and "enum34"
@@ -1213,7 +1267,9 @@ def test_run_without_specific_version(murlopen, tmpfile):
         with open(filename, "w") as f:
             f.write("")
 
-        retcode = hashin.run("hashin", filename, "sha256", verbose=True, index_url="https://pypi.org/")
+        retcode = hashin.run(
+            "hashin", filename, "sha256", verbose=True, index_url="https://pypi.org/"
+        )
 
         assert retcode == 0
         with open(filename) as f:
@@ -1272,7 +1328,13 @@ def test_run_contained_names(murlopen, tmpfile):
         with open(filename, "w") as f:
             f.write("")
 
-        retcode = hashin.run("django-redis==4.7.0", filename, "sha256", verbose=True, index_url="https://pypi.org/")
+        retcode = hashin.run(
+            "django-redis==4.7.0",
+            filename,
+            "sha256",
+            verbose=True,
+            index_url="https://pypi.org/",
+        )
 
         assert retcode == 0
         with open(filename) as f:
@@ -1284,7 +1346,13 @@ def test_run_contained_names(murlopen, tmpfile):
 
         # Now install the next package whose name is contained
         # in the first one.
-        retcode = hashin.run("redis==2.10.5", filename, "sha256", verbose=True, index_url="https://pypi.org/")
+        retcode = hashin.run(
+            "redis==2.10.5",
+            filename,
+            "sha256",
+            verbose=True,
+            index_url="https://pypi.org/",
+        )
 
         assert retcode == 0
         with open(filename) as f:
@@ -1454,7 +1522,9 @@ def test_run_case_insensitive(murlopen, tmpfile):
             f.write("    --hash=sha256:12ce5c2ef718\n")
             f.write("\n")
 
-        retcode = hashin.run(None, filename, "sha256", verbose=True, index_url="https://pypi.org/")
+        retcode = hashin.run(
+            None, filename, "sha256", verbose=True, index_url="https://pypi.org/"
+        )
 
         assert retcode == 0
         with open(filename) as f:
@@ -1514,7 +1584,13 @@ def test_run_update_all(murlopen, tmpfile):
         with open(filename, "w") as f:
             f.write("")
 
-        retcode = hashin.run("HAShin==0.10", filename, "sha256", verbose=True, index_url="https://pypi.org/")
+        retcode = hashin.run(
+            "HAShin==0.10",
+            filename,
+            "sha256",
+            verbose=True,
+            index_url="https://pypi.org/",
+        )
 
         assert retcode == 0
         with open(filename) as f:
@@ -1524,7 +1600,9 @@ def test_run_update_all(murlopen, tmpfile):
         assert lines[0] == "hashin==0.10 \\"
 
         # Change version
-        retcode = hashin.run("hashIN==0.11", filename, "sha256", index_url="https://pypi.org/")
+        retcode = hashin.run(
+            "hashIN==0.11", filename, "sha256", index_url="https://pypi.org/"
+        )
         assert retcode == 0
         with open(filename) as f:
             output = f.read()
@@ -1609,7 +1687,12 @@ def test_run_dry(murlopen, tmpfile, capsys):
             f.write("")
 
         retcode = hashin.run(
-            "hashin==0.10", filename, "sha256", verbose=False, dry_run=True, index_url="https://pypi.org/"
+            "hashin==0.10",
+            filename,
+            "sha256",
+            verbose=False,
+            dry_run=True,
+            index_url="https://pypi.org/",
         )
         assert retcode == 0
 
@@ -1675,7 +1758,12 @@ def test_run_dry_multiple_packages(murlopen, tmpfile, capsys):
             f.write("")
 
         retcode = hashin.run(
-            ["hashin", "requests"], filename, "sha256", verbose=False, dry_run=True, index_url="https://pypi.org/"
+            ["hashin", "requests"],
+            filename,
+            "sha256",
+            verbose=False,
+            dry_run=True,
+            index_url="https://pypi.org/",
         )
         assert retcode == 0
 
@@ -1795,7 +1883,11 @@ def test_run_pep_0496(murlopen, tmpfile):
             f.write("")
 
         retcode = hashin.run(
-            "enum34==1.1.6; python_version <= '3.4'", filename, "sha256", verbose=True, index_url="https://pypi.org/"
+            "enum34==1.1.6; python_version <= '3.4'",
+            filename,
+            "sha256",
+            verbose=True,
+            index_url="https://pypi.org/",
         )
 
         assert retcode == 0
@@ -1994,7 +2086,10 @@ def test_get_package_hashes(murlopen):
     murlopen.side_effect = mocked_get
 
     result = hashin.get_package_hashes(
-        package="hashin", version="0.10", algorithm="sha256", index_url="https://pypi.org/"
+        package="hashin",
+        version="0.10",
+        algorithm="sha256",
+        index_url="https://pypi.org/",
     )
 
     expected = {
@@ -2026,14 +2121,20 @@ def test_get_package_hashes_package_not_found(murlopen):
 
     with pytest.raises(hashin.PackageNotFoundError) as exc_info:
         hashin.get_package_hashes(
-            package="gobblygook", version="0.10", algorithm="sha256", index_url="https://pypi.org/"
+            package="gobblygook",
+            version="0.10",
+            algorithm="sha256",
+            index_url="https://pypi.org/",
         )
     assert str(exc_info.value) == "https://pypi.org/pypi/gobblygook/json"
 
     # Errors left as is if not a 404
     with pytest.raises(hashin.PackageError):
         hashin.get_package_hashes(
-            package="troublemaker", version="0.10", algorithm="sha256", index_url="https://pypi.org/"
+            package="troublemaker",
+            version="0.10",
+            algorithm="sha256",
+            index_url="https://pypi.org/",
         )
 
 
@@ -2077,7 +2178,11 @@ def test_get_package_hashes_unknown_algorithm(murlopen, capsys):
     murlopen.side_effect = mocked_get
 
     result = hashin.get_package_hashes(
-        package="hashin", version="0.10", algorithm="sha512", verbose=True, index_url="https://pypi.org/"
+        package="hashin",
+        version="0.10",
+        algorithm="sha512",
+        verbose=True,
+        index_url="https://pypi.org/",
     )
     captured = capsys.readouterr()
     out_lines = captured.out.splitlines()
@@ -2141,7 +2246,9 @@ def test_get_package_hashes_without_version(murlopen, capsys):
 
     murlopen.side_effect = mocked_get
 
-    result = hashin.get_package_hashes(package="hashin", verbose=True, index_url="https://pypi.org/")
+    result = hashin.get_package_hashes(
+        package="hashin", verbose=True, index_url="https://pypi.org/"
+    )
     assert result["package"] == "hashin"
     assert result["version"] == "0.10"
     assert result["hashes"]
@@ -2151,12 +2258,19 @@ def test_get_package_hashes_without_version(murlopen, capsys):
     # Let's do it again and mess with a few things.
     # First specify python_versions.
     result = hashin.get_package_hashes(
-        package="hashin", verbose=True, python_versions=("3.5",), index_url="https://pypi.org/"
+        package="hashin",
+        verbose=True,
+        python_versions=("3.5",),
+        index_url="https://pypi.org/",
     )
     assert len(result["hashes"]) == 2  # instead of 3
     # Specify an unrecognized python version
     with pytest.raises(hashin.PackageError):
-        hashin.get_package_hashes(package="hashin", python_versions=("2.99999",), index_url="https://pypi.org/")
+        hashin.get_package_hashes(
+            package="hashin",
+            python_versions=("2.99999",),
+            index_url="https://pypi.org/",
+        )
 
     # Look for a package without any releases
     with pytest.raises(hashin.PackageError):
@@ -2194,7 +2308,9 @@ def test_with_extras_syntax(murlopen, tmpfile):
         with open(filename, "w") as f:
             f.write("")
 
-        retcode = hashin.run("hashin[stuff]", filename, "sha256", index_url="https://pypi.org/")
+        retcode = hashin.run(
+            "hashin[stuff]", filename, "sha256", index_url="https://pypi.org/"
+        )
 
         assert retcode == 0
         with open(filename) as f:
@@ -2227,7 +2343,9 @@ def test_extras_syntax_edit(murlopen, tmpfile):
             f.write("hashin==0.10\n")
             f.write("    --hash=sha256:ccccc\n")
 
-        retcode = hashin.run("hashin[stuff]", filename, "sha256", index_url="https://pypi.org/")
+        retcode = hashin.run(
+            "hashin[stuff]", filename, "sha256", index_url="https://pypi.org/"
+        )
 
         assert retcode == 0
         with open(filename) as f:
@@ -2261,7 +2379,9 @@ def test_add_extra_extras_syntax_edit(murlopen, tmpfile):
             f.write("hashin[stuff]==0.10\n")
             f.write("    --hash=sha256:ccccc\n")
 
-        retcode = hashin.run("hashin[extra,stuff]", filename, "sha256", index_url="https://pypi.org/")
+        retcode = hashin.run(
+            "hashin[extra,stuff]", filename, "sha256", index_url="https://pypi.org/"
+        )
 
         assert retcode == 0
         with open(filename) as f:
@@ -2297,7 +2417,9 @@ def test_change_extra_extras_syntax_edit(murlopen, tmpfile):
             f.write("hashin[stuff]==0.10\n")
             f.write("    --hash=sha256:ccccc\n")
 
-        retcode = hashin.run("hashin[different]", filename, "sha256", index_url="https://pypi.org/")
+        retcode = hashin.run(
+            "hashin[different]", filename, "sha256", index_url="https://pypi.org/"
+        )
 
         assert retcode == 0
         with open(filename) as f:
@@ -2331,7 +2453,9 @@ def test_remove_extra_extras_syntax_edit(murlopen, tmpfile):
             f.write("hashin[stuff]==0.10\n")
             f.write("    --hash=sha256:ccccc\n")
 
-        retcode = hashin.run("hashin", filename, "sha256", index_url="https://pypi.org/")
+        retcode = hashin.run(
+            "hashin", filename, "sha256", index_url="https://pypi.org/"
+        )
 
         assert retcode == 0
         with open(filename) as f:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -117,12 +117,7 @@ def test_get_hashes_error(murlopen):
 
     murlopen.side_effect = mocked_get
     with pytest.raises(hashin.PackageError):
-        hashin.run(
-            "somepackage==1.2.3",
-            "doesntmatter.txt",
-            "sha256",
-            index_url="https://pypi.org/",
-        )
+        hashin.run("somepackage==1.2.3", "doesntmatter.txt", "sha256")
 
 
 def test_non_200_ok_download(murlopen):
@@ -132,12 +127,7 @@ def test_non_200_ok_download(murlopen):
     murlopen.side_effect = mocked_get
 
     with pytest.raises(hashin.PackageError):
-        hashin.run(
-            "somepackage==1.2.3",
-            "doesntmatter.txt",
-            "sha256",
-            index_url="https://pypi.org/",
-        )
+        hashin.run("somepackage==1.2.3", "doesntmatter.txt", "sha256")
 
 
 def test_main_packageerrors_stderr(mock_run, capsys, mock_get_parser):
@@ -156,7 +146,7 @@ def test_main_packageerrors_stderr(mock_run, capsys, mock_get_parser):
             update_all=False,
             interactive=False,
             synchronous=False,
-            index_url="https://pypi.org/",
+            index_url=None,
         )
 
     mock_get_parser().parse_args.side_effect = mock_parse_args
@@ -602,13 +592,7 @@ def test_run(murlopen, tmpfile, capsys):
         with open(filename, "w") as f:
             f.write("")
 
-        retcode = hashin.run(
-            "hashin==0.10",
-            filename,
-            "sha256",
-            verbose=True,
-            index_url="https://pypi.org/",
-        )
+        retcode = hashin.run("hashin==0.10", filename, "sha256", verbose=True)
 
         assert retcode == 0
         with open(filename) as f:
@@ -639,9 +623,7 @@ def test_run(murlopen, tmpfile, capsys):
         assert "aaaaa" in out_lines[2], out_lines[2]
 
         # Change algorithm
-        retcode = hashin.run(
-            "hashin==0.10", filename, "sha512", index_url="https://pypi.org/"
-        )
+        retcode = hashin.run("hashin==0.10", filename, "sha512")
         assert retcode == 0
         with open(filename) as f:
             output = f.read()
@@ -706,13 +688,7 @@ def test_run_atomic_not_write_with_error_on_last_package(murlopen, tmpfile):
             f.write("")
 
         with pytest.raises(hashin.PackageNotFoundError):
-            hashin.run(
-                ["hashin", "gobblygook"],
-                filename,
-                "sha256",
-                verbose=True,
-                index_url="https://pypi.org/",
-            )
+            hashin.run(["hashin", "gobblygook"], filename, "sha256", verbose=True)
 
         with open(filename) as f:
             output = f.read()
@@ -864,13 +840,7 @@ enum34==1.1.5; python_version <= '3.4' \\
 
         # Basically means we're saying "No" to all of them.
         with mock.patch("hashin.input", return_value="N"):
-            retcode = hashin.run(
-                None,
-                filename,
-                "sha256",
-                interactive=True,
-                index_url="https://pypi.org/",
-            )
+            retcode = hashin.run(None, filename, "sha256", interactive=True)
         assert retcode == 0
 
         with open(filename) as f:
@@ -891,13 +861,7 @@ enum34==1.1.5; python_version <= '3.4' \\
 
         with mock.patch("hashin.input") as mocked_input:
             mocked_input.side_effect = mock_input
-            retcode = hashin.run(
-                None,
-                filename,
-                "sha256",
-                interactive=True,
-                index_url="https://pypi.org/",
-            )
+            retcode = hashin.run(None, filename, "sha256", interactive=True)
         assert retcode == 0
 
         # The expected output is that only "requests[security]" and "enum34"
@@ -1075,13 +1039,7 @@ enum34==1.1.5; python_version <= '3.4' \\
 
         with mock.patch("hashin.input") as mocked_input:
             mocked_input.side_effect = mock_input
-            retcode = hashin.run(
-                None,
-                filename,
-                "sha256",
-                interactive=True,
-                index_url="https://pypi.org/",
-            )
+            retcode = hashin.run(None, filename, "sha256", interactive=True)
         assert retcode != 0
         assert len(questions) == 1
 
@@ -1091,13 +1049,7 @@ enum34==1.1.5; python_version <= '3.4' \\
 
         with mock.patch("hashin.input") as mocked_input:
             mocked_input.side_effect = mock_input
-            retcode = hashin.run(
-                None,
-                filename,
-                "sha256",
-                interactive=True,
-                index_url="https://pypi.org/",
-            )
+            retcode = hashin.run(None, filename, "sha256", interactive=True)
         assert retcode == 0
 
         # The expected output is that only "requests[security]" and "enum34"
@@ -1206,13 +1158,7 @@ Hash-in==0.9 \\
             assert output == before
 
         with mock.patch("hashin.input", return_value="Y"):
-            retcode = hashin.run(
-                None,
-                filename,
-                "sha256",
-                interactive=True,
-                index_url="https://pypi.org/",
-            )
+            retcode = hashin.run(None, filename, "sha256", interactive=True)
         assert retcode == 0
 
         # The expected output is that only "requests[security]" and "enum34"
@@ -1267,9 +1213,7 @@ def test_run_without_specific_version(murlopen, tmpfile):
         with open(filename, "w") as f:
             f.write("")
 
-        retcode = hashin.run(
-            "hashin", filename, "sha256", verbose=True, index_url="https://pypi.org/"
-        )
+        retcode = hashin.run("hashin", filename, "sha256", verbose=True)
 
         assert retcode == 0
         with open(filename) as f:
@@ -1375,13 +1319,7 @@ def test_run_contained_names(murlopen, tmpfile):
         with open(filename, "w") as f:
             f.write("")
 
-        retcode = hashin.run(
-            "django-redis==4.7.0",
-            filename,
-            "sha256",
-            verbose=True,
-            index_url="https://pypi.org/",
-        )
+        retcode = hashin.run("django-redis==4.7.0", filename, "sha256", verbose=True)
 
         assert retcode == 0
         with open(filename) as f:
@@ -1393,13 +1331,7 @@ def test_run_contained_names(murlopen, tmpfile):
 
         # Now install the next package whose name is contained
         # in the first one.
-        retcode = hashin.run(
-            "redis==2.10.5",
-            filename,
-            "sha256",
-            verbose=True,
-            index_url="https://pypi.org/",
-        )
+        retcode = hashin.run("redis==2.10.5", filename, "sha256", verbose=True)
 
         assert retcode == 0
         with open(filename) as f:
@@ -1556,7 +1488,7 @@ def test_run_case_insensitive(murlopen, tmpfile):
 
     with tmpfile() as filename:
         with pytest.raises(FileNotFoundError):
-            hashin.run(None, filename, "sha256", index_url="https://pypi.org/")
+            hashin.run(None, filename, "sha256")
 
         with open(filename, "w") as f:
             f.write("# This is comment. Ignore this.\n")
@@ -1569,9 +1501,7 @@ def test_run_case_insensitive(murlopen, tmpfile):
             f.write("    --hash=sha256:12ce5c2ef718\n")
             f.write("\n")
 
-        retcode = hashin.run(
-            None, filename, "sha256", verbose=True, index_url="https://pypi.org/"
-        )
+        retcode = hashin.run(None, filename, "sha256", verbose=True)
 
         assert retcode == 0
         with open(filename) as f:
@@ -1631,13 +1561,7 @@ def test_run_update_all(murlopen, tmpfile):
         with open(filename, "w") as f:
             f.write("")
 
-        retcode = hashin.run(
-            "HAShin==0.10",
-            filename,
-            "sha256",
-            verbose=True,
-            index_url="https://pypi.org/",
-        )
+        retcode = hashin.run("HAShin==0.10", filename, "sha256", verbose=True)
 
         assert retcode == 0
         with open(filename) as f:
@@ -1647,9 +1571,7 @@ def test_run_update_all(murlopen, tmpfile):
         assert lines[0] == "hashin==0.10 \\"
 
         # Change version
-        retcode = hashin.run(
-            "hashIN==0.11", filename, "sha256", index_url="https://pypi.org/"
-        )
+        retcode = hashin.run("hashIN==0.11", filename, "sha256")
         assert retcode == 0
         with open(filename) as f:
             output = f.read()
@@ -1695,7 +1617,7 @@ def test_run_comments_with_package_spec_patterns(murlopen, tmpfile, capsys):
             f.write("    --hash=sha256:bbbbb\n")
             f.write("\n")
 
-        retcode = hashin.run([], filename, "sha256", index_url="https://pypi.org/")
+        retcode = hashin.run([], filename, "sha256")
         # Since this is based a stupidity test, just be content that it works.
         assert retcode == 0
 
@@ -1734,12 +1656,7 @@ def test_run_dry(murlopen, tmpfile, capsys):
             f.write("")
 
         retcode = hashin.run(
-            "hashin==0.10",
-            filename,
-            "sha256",
-            verbose=False,
-            dry_run=True,
-            index_url="https://pypi.org/",
+            "hashin==0.10", filename, "sha256", verbose=False, dry_run=True
         )
         assert retcode == 0
 
@@ -1805,12 +1722,7 @@ def test_run_dry_multiple_packages(murlopen, tmpfile, capsys):
             f.write("")
 
         retcode = hashin.run(
-            ["hashin", "requests"],
-            filename,
-            "sha256",
-            verbose=False,
-            dry_run=True,
-            index_url="https://pypi.org/",
+            ["hashin", "requests"], filename, "sha256", verbose=False, dry_run=True
         )
         assert retcode == 0
 
@@ -1930,11 +1842,7 @@ def test_run_pep_0496(murlopen, tmpfile):
             f.write("")
 
         retcode = hashin.run(
-            "enum34==1.1.6; python_version <= '3.4'",
-            filename,
-            "sha256",
-            verbose=True,
-            index_url="https://pypi.org/",
+            "enum34==1.1.6; python_version <= '3.4'", filename, "sha256", verbose=True
         )
 
         assert retcode == 0
@@ -2133,10 +2041,7 @@ def test_get_package_hashes(murlopen):
     murlopen.side_effect = mocked_get
 
     result = hashin.get_package_hashes(
-        package="hashin",
-        version="0.10",
-        algorithm="sha256",
-        index_url="https://pypi.org/",
+        package="hashin", version="0.10", algorithm="sha256"
     )
 
     expected = {
@@ -2213,20 +2118,14 @@ def test_get_package_hashes_package_not_found(murlopen):
 
     with pytest.raises(hashin.PackageNotFoundError) as exc_info:
         hashin.get_package_hashes(
-            package="gobblygook",
-            version="0.10",
-            algorithm="sha256",
-            index_url="https://pypi.org/",
+            package="gobblygook", version="0.10", algorithm="sha256"
         )
     assert str(exc_info.value) == "https://pypi.org/pypi/gobblygook/json"
 
     # Errors left as is if not a 404
     with pytest.raises(hashin.PackageError):
         hashin.get_package_hashes(
-            package="troublemaker",
-            version="0.10",
-            algorithm="sha256",
-            index_url="https://pypi.org/",
+            package="troublemaker", version="0.10", algorithm="sha256"
         )
 
 
@@ -2270,11 +2169,7 @@ def test_get_package_hashes_unknown_algorithm(murlopen, capsys):
     murlopen.side_effect = mocked_get
 
     result = hashin.get_package_hashes(
-        package="hashin",
-        version="0.10",
-        algorithm="sha512",
-        verbose=True,
-        index_url="https://pypi.org/",
+        package="hashin", version="0.10", algorithm="sha512", verbose=True
     )
     captured = capsys.readouterr()
     out_lines = captured.out.splitlines()
@@ -2338,9 +2233,7 @@ def test_get_package_hashes_without_version(murlopen, capsys):
 
     murlopen.side_effect = mocked_get
 
-    result = hashin.get_package_hashes(
-        package="hashin", verbose=True, index_url="https://pypi.org/"
-    )
+    result = hashin.get_package_hashes(package="hashin", verbose=True)
     assert result["package"] == "hashin"
     assert result["version"] == "0.10"
     assert result["hashes"]
@@ -2350,23 +2243,16 @@ def test_get_package_hashes_without_version(murlopen, capsys):
     # Let's do it again and mess with a few things.
     # First specify python_versions.
     result = hashin.get_package_hashes(
-        package="hashin",
-        verbose=True,
-        python_versions=("3.5",),
-        index_url="https://pypi.org/",
+        package="hashin", verbose=True, python_versions=("3.5",)
     )
     assert len(result["hashes"]) == 2  # instead of 3
     # Specify an unrecognized python version
     with pytest.raises(hashin.PackageError):
-        hashin.get_package_hashes(
-            package="hashin",
-            python_versions=("2.99999",),
-            index_url="https://pypi.org/",
-        )
+        hashin.get_package_hashes(package="hashin", python_versions=("2.99999",))
 
     # Look for a package without any releases
     with pytest.raises(hashin.PackageError):
-        hashin.get_package_hashes(package="uggamugga", index_url="https://pypi.org/")
+        hashin.get_package_hashes(package="uggamugga")
 
 
 def test_with_extras_syntax(murlopen, tmpfile):
@@ -2400,9 +2286,7 @@ def test_with_extras_syntax(murlopen, tmpfile):
         with open(filename, "w") as f:
             f.write("")
 
-        retcode = hashin.run(
-            "hashin[stuff]", filename, "sha256", index_url="https://pypi.org/"
-        )
+        retcode = hashin.run("hashin[stuff]", filename, "sha256")
 
         assert retcode == 0
         with open(filename) as f:
@@ -2435,9 +2319,7 @@ def test_extras_syntax_edit(murlopen, tmpfile):
             f.write("hashin==0.10\n")
             f.write("    --hash=sha256:ccccc\n")
 
-        retcode = hashin.run(
-            "hashin[stuff]", filename, "sha256", index_url="https://pypi.org/"
-        )
+        retcode = hashin.run("hashin[stuff]", filename, "sha256")
 
         assert retcode == 0
         with open(filename) as f:
@@ -2471,9 +2353,7 @@ def test_add_extra_extras_syntax_edit(murlopen, tmpfile):
             f.write("hashin[stuff]==0.10\n")
             f.write("    --hash=sha256:ccccc\n")
 
-        retcode = hashin.run(
-            "hashin[extra,stuff]", filename, "sha256", index_url="https://pypi.org/"
-        )
+        retcode = hashin.run("hashin[extra,stuff]", filename, "sha256")
 
         assert retcode == 0
         with open(filename) as f:
@@ -2509,9 +2389,7 @@ def test_change_extra_extras_syntax_edit(murlopen, tmpfile):
             f.write("hashin[stuff]==0.10\n")
             f.write("    --hash=sha256:ccccc\n")
 
-        retcode = hashin.run(
-            "hashin[different]", filename, "sha256", index_url="https://pypi.org/"
-        )
+        retcode = hashin.run("hashin[different]", filename, "sha256")
 
         assert retcode == 0
         with open(filename) as f:
@@ -2545,9 +2423,7 @@ def test_remove_extra_extras_syntax_edit(murlopen, tmpfile):
             f.write("hashin[stuff]==0.10\n")
             f.write("    --hash=sha256:ccccc\n")
 
-        retcode = hashin.run(
-            "hashin", filename, "sha256", index_url="https://pypi.org/"
-        )
+        retcode = hashin.run("hashin", filename, "sha256")
 
         assert retcode == 0
         with open(filename) as f:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1277,6 +1277,53 @@ def test_run_without_specific_version(murlopen, tmpfile):
         assert output.startswith("hashin==0.10")
 
 
+def test_run_with_alternate_index_url(murlopen, tmpfile):
+    def mocked_get(url, **options):
+        if url == "https://pypi.internal.net/pypi/hashin/json":
+            return _Response(
+                {
+                    "info": {"version": "0.10", "name": "hashin"},
+                    "releases": {
+                        "0.10": [
+                            {
+                                "url": "https://pypi.internal.net/packages/2.7/p/hashin/hashin-0.10-py2-none-any.whl",
+                                "digests": {"sha256": "aaaaa"},
+                            },
+                            {
+                                "url": "https://pypi.internal.net/packages/3.3/p/hashin/hashin-0.10-py3-none-any.whl",
+                                "digests": {"sha256": "bbbbb"},
+                            },
+                            {
+                                "url": "https://pypi.internal.net/packages/source/p/hashin/hashin-0.10.tar.gz",
+                                "digests": {"sha256": "ccccc"},
+                            },
+                        ]
+                    },
+                }
+            )
+
+        raise NotImplementedError(url)
+
+    murlopen.side_effect = mocked_get
+
+    with tmpfile() as filename:
+        with open(filename, "w") as f:
+            f.write("")
+
+        retcode = hashin.run(
+            "hashin",
+            filename,
+            "sha256",
+            verbose=True,
+            index_url="https://pypi.internal.net/",
+        )
+
+        assert retcode == 0
+        with open(filename) as f:
+            output = f.read()
+        assert output.startswith("hashin==0.10")
+
+
 def test_run_contained_names(murlopen, tmpfile):
     """
     This is based on https://github.com/peterbe/hashin/issues/35
@@ -2096,6 +2143,51 @@ def test_get_package_hashes(murlopen):
         "package": "hashin",
         "version": "0.10",
         "hashes": [{"hash": "aaaaa"}, {"hash": "bbbbb"}, {"hash": "ccccc"}],
+    }
+
+    assert result == expected
+
+
+def test_get_package_hashes_from_alternate_index_url(murlopen):
+    def mocked_get(url, **options):
+        if url == "https://pypi.internal.net/pypi/hashin/json":
+            return _Response(
+                {
+                    "info": {"version": "0.10", "name": "hashin"},
+                    "releases": {
+                        "0.10": [
+                            {
+                                "url": "https://pypi.internal.net/packages/2.7/p/hashin/hashin-0.10-py2-none-any.whl",
+                                "digests": {"sha256": "ddddd"},
+                            },
+                            {
+                                "url": "https://pypi.internal.net/packages/3.3/p/hashin/hashin-0.10-py3-none-any.whl",
+                                "digests": {"sha256": "eeeee"},
+                            },
+                            {
+                                "url": "https://pypi.internal.net/packages/source/p/hashin/hashin-0.10.tar.gz",
+                                "digests": {"sha256": "fffff"},
+                            },
+                        ]
+                    },
+                }
+            )
+
+        raise NotImplementedError(url)
+
+    murlopen.side_effect = mocked_get
+
+    result = hashin.get_package_hashes(
+        package="hashin",
+        version="0.10",
+        algorithm="sha256",
+        index_url="https://pypi.internal.net/",
+    )
+
+    expected = {
+        "package": "hashin",
+        "version": "0.10",
+        "hashes": [{"hash": "ddddd"}, {"hash": "eeeee"}, {"hash": "fffff"}],
     }
 
     assert result == expected

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -117,7 +117,7 @@ def test_get_hashes_error(murlopen):
 
     murlopen.side_effect = mocked_get
     with pytest.raises(hashin.PackageError):
-        hashin.run("somepackage==1.2.3", "doesntmatter.txt", "sha256")
+        hashin.run("somepackage==1.2.3", "doesntmatter.txt", "sha256", index_url="https://pypi.org/")
 
 
 def test_non_200_ok_download(murlopen):
@@ -127,7 +127,7 @@ def test_non_200_ok_download(murlopen):
     murlopen.side_effect = mocked_get
 
     with pytest.raises(hashin.PackageError):
-        hashin.run("somepackage==1.2.3", "doesntmatter.txt", "sha256")
+        hashin.run("somepackage==1.2.3", "doesntmatter.txt", "sha256", index_url="https://pypi.org/")
 
 
 def test_main_packageerrors_stderr(mock_run, capsys, mock_get_parser):
@@ -146,6 +146,7 @@ def test_main_packageerrors_stderr(mock_run, capsys, mock_get_parser):
             update_all=False,
             interactive=False,
             synchronous=False,
+            index_url="https://pypi.org/",
         )
 
     mock_get_parser().parse_args.side_effect = mock_parse_args
@@ -591,7 +592,7 @@ def test_run(murlopen, tmpfile, capsys):
         with open(filename, "w") as f:
             f.write("")
 
-        retcode = hashin.run("hashin==0.10", filename, "sha256", verbose=True)
+        retcode = hashin.run("hashin==0.10", filename, "sha256", verbose=True, index_url="https://pypi.org/")
 
         assert retcode == 0
         with open(filename) as f:
@@ -622,7 +623,7 @@ def test_run(murlopen, tmpfile, capsys):
         assert "aaaaa" in out_lines[2], out_lines[2]
 
         # Change algorithm
-        retcode = hashin.run("hashin==0.10", filename, "sha512")
+        retcode = hashin.run("hashin==0.10", filename, "sha512", index_url="https://pypi.org/")
         assert retcode == 0
         with open(filename) as f:
             output = f.read()
@@ -687,7 +688,7 @@ def test_run_atomic_not_write_with_error_on_last_package(murlopen, tmpfile):
             f.write("")
 
         with pytest.raises(hashin.PackageNotFoundError):
-            hashin.run(["hashin", "gobblygook"], filename, "sha256", verbose=True)
+            hashin.run(["hashin", "gobblygook"], filename, "sha256", verbose=True, index_url="https://pypi.org/")
 
         with open(filename) as f:
             output = f.read()
@@ -839,7 +840,7 @@ enum34==1.1.5; python_version <= '3.4' \\
 
         # Basically means we're saying "No" to all of them.
         with mock.patch("hashin.input", return_value="N"):
-            retcode = hashin.run(None, filename, "sha256", interactive=True)
+            retcode = hashin.run(None, filename, "sha256", interactive=True, index_url="https://pypi.org/")
         assert retcode == 0
 
         with open(filename) as f:
@@ -860,7 +861,7 @@ enum34==1.1.5; python_version <= '3.4' \\
 
         with mock.patch("hashin.input") as mocked_input:
             mocked_input.side_effect = mock_input
-            retcode = hashin.run(None, filename, "sha256", interactive=True)
+            retcode = hashin.run(None, filename, "sha256", interactive=True, index_url="https://pypi.org/")
         assert retcode == 0
 
         # The expected output is that only "requests[security]" and "enum34"
@@ -1038,7 +1039,7 @@ enum34==1.1.5; python_version <= '3.4' \\
 
         with mock.patch("hashin.input") as mocked_input:
             mocked_input.side_effect = mock_input
-            retcode = hashin.run(None, filename, "sha256", interactive=True)
+            retcode = hashin.run(None, filename, "sha256", interactive=True, index_url="https://pypi.org/")
         assert retcode != 0
         assert len(questions) == 1
 
@@ -1048,7 +1049,7 @@ enum34==1.1.5; python_version <= '3.4' \\
 
         with mock.patch("hashin.input") as mocked_input:
             mocked_input.side_effect = mock_input
-            retcode = hashin.run(None, filename, "sha256", interactive=True)
+            retcode = hashin.run(None, filename, "sha256", interactive=True, index_url="https://pypi.org/")
         assert retcode == 0
 
         # The expected output is that only "requests[security]" and "enum34"
@@ -1157,7 +1158,7 @@ Hash-in==0.9 \\
             assert output == before
 
         with mock.patch("hashin.input", return_value="Y"):
-            retcode = hashin.run(None, filename, "sha256", interactive=True)
+            retcode = hashin.run(None, filename, "sha256", interactive=True, index_url="https://pypi.org/")
         assert retcode == 0
 
         # The expected output is that only "requests[security]" and "enum34"
@@ -1212,7 +1213,7 @@ def test_run_without_specific_version(murlopen, tmpfile):
         with open(filename, "w") as f:
             f.write("")
 
-        retcode = hashin.run("hashin", filename, "sha256", verbose=True)
+        retcode = hashin.run("hashin", filename, "sha256", verbose=True, index_url="https://pypi.org/")
 
         assert retcode == 0
         with open(filename) as f:
@@ -1271,7 +1272,7 @@ def test_run_contained_names(murlopen, tmpfile):
         with open(filename, "w") as f:
             f.write("")
 
-        retcode = hashin.run("django-redis==4.7.0", filename, "sha256", verbose=True)
+        retcode = hashin.run("django-redis==4.7.0", filename, "sha256", verbose=True, index_url="https://pypi.org/")
 
         assert retcode == 0
         with open(filename) as f:
@@ -1283,7 +1284,7 @@ def test_run_contained_names(murlopen, tmpfile):
 
         # Now install the next package whose name is contained
         # in the first one.
-        retcode = hashin.run("redis==2.10.5", filename, "sha256", verbose=True)
+        retcode = hashin.run("redis==2.10.5", filename, "sha256", verbose=True, index_url="https://pypi.org/")
 
         assert retcode == 0
         with open(filename) as f:
@@ -1440,7 +1441,7 @@ def test_run_case_insensitive(murlopen, tmpfile):
 
     with tmpfile() as filename:
         with pytest.raises(FileNotFoundError):
-            hashin.run(None, filename, "sha256")
+            hashin.run(None, filename, "sha256", index_url="https://pypi.org/")
 
         with open(filename, "w") as f:
             f.write("# This is comment. Ignore this.\n")
@@ -1453,7 +1454,7 @@ def test_run_case_insensitive(murlopen, tmpfile):
             f.write("    --hash=sha256:12ce5c2ef718\n")
             f.write("\n")
 
-        retcode = hashin.run(None, filename, "sha256", verbose=True)
+        retcode = hashin.run(None, filename, "sha256", verbose=True, index_url="https://pypi.org/")
 
         assert retcode == 0
         with open(filename) as f:
@@ -1513,7 +1514,7 @@ def test_run_update_all(murlopen, tmpfile):
         with open(filename, "w") as f:
             f.write("")
 
-        retcode = hashin.run("HAShin==0.10", filename, "sha256", verbose=True)
+        retcode = hashin.run("HAShin==0.10", filename, "sha256", verbose=True, index_url="https://pypi.org/")
 
         assert retcode == 0
         with open(filename) as f:
@@ -1523,7 +1524,7 @@ def test_run_update_all(murlopen, tmpfile):
         assert lines[0] == "hashin==0.10 \\"
 
         # Change version
-        retcode = hashin.run("hashIN==0.11", filename, "sha256")
+        retcode = hashin.run("hashIN==0.11", filename, "sha256", index_url="https://pypi.org/")
         assert retcode == 0
         with open(filename) as f:
             output = f.read()
@@ -1569,7 +1570,7 @@ def test_run_comments_with_package_spec_patterns(murlopen, tmpfile, capsys):
             f.write("    --hash=sha256:bbbbb\n")
             f.write("\n")
 
-        retcode = hashin.run([], filename, "sha256")
+        retcode = hashin.run([], filename, "sha256", index_url="https://pypi.org/")
         # Since this is based a stupidity test, just be content that it works.
         assert retcode == 0
 
@@ -1608,7 +1609,7 @@ def test_run_dry(murlopen, tmpfile, capsys):
             f.write("")
 
         retcode = hashin.run(
-            "hashin==0.10", filename, "sha256", verbose=False, dry_run=True
+            "hashin==0.10", filename, "sha256", verbose=False, dry_run=True, index_url="https://pypi.org/"
         )
         assert retcode == 0
 
@@ -1674,7 +1675,7 @@ def test_run_dry_multiple_packages(murlopen, tmpfile, capsys):
             f.write("")
 
         retcode = hashin.run(
-            ["hashin", "requests"], filename, "sha256", verbose=False, dry_run=True
+            ["hashin", "requests"], filename, "sha256", verbose=False, dry_run=True, index_url="https://pypi.org/"
         )
         assert retcode == 0
 
@@ -1794,7 +1795,7 @@ def test_run_pep_0496(murlopen, tmpfile):
             f.write("")
 
         retcode = hashin.run(
-            "enum34==1.1.6; python_version <= '3.4'", filename, "sha256", verbose=True
+            "enum34==1.1.6; python_version <= '3.4'", filename, "sha256", verbose=True, index_url="https://pypi.org/"
         )
 
         assert retcode == 0
@@ -1993,7 +1994,7 @@ def test_get_package_hashes(murlopen):
     murlopen.side_effect = mocked_get
 
     result = hashin.get_package_hashes(
-        package="hashin", version="0.10", algorithm="sha256"
+        package="hashin", version="0.10", algorithm="sha256", index_url="https://pypi.org/"
     )
 
     expected = {
@@ -2025,14 +2026,14 @@ def test_get_package_hashes_package_not_found(murlopen):
 
     with pytest.raises(hashin.PackageNotFoundError) as exc_info:
         hashin.get_package_hashes(
-            package="gobblygook", version="0.10", algorithm="sha256"
+            package="gobblygook", version="0.10", algorithm="sha256", index_url="https://pypi.org/"
         )
     assert str(exc_info.value) == "https://pypi.org/pypi/gobblygook/json"
 
     # Errors left as is if not a 404
     with pytest.raises(hashin.PackageError):
         hashin.get_package_hashes(
-            package="troublemaker", version="0.10", algorithm="sha256"
+            package="troublemaker", version="0.10", algorithm="sha256", index_url="https://pypi.org/"
         )
 
 
@@ -2076,7 +2077,7 @@ def test_get_package_hashes_unknown_algorithm(murlopen, capsys):
     murlopen.side_effect = mocked_get
 
     result = hashin.get_package_hashes(
-        package="hashin", version="0.10", algorithm="sha512", verbose=True
+        package="hashin", version="0.10", algorithm="sha512", verbose=True, index_url="https://pypi.org/"
     )
     captured = capsys.readouterr()
     out_lines = captured.out.splitlines()
@@ -2140,7 +2141,7 @@ def test_get_package_hashes_without_version(murlopen, capsys):
 
     murlopen.side_effect = mocked_get
 
-    result = hashin.get_package_hashes(package="hashin", verbose=True)
+    result = hashin.get_package_hashes(package="hashin", verbose=True, index_url="https://pypi.org/")
     assert result["package"] == "hashin"
     assert result["version"] == "0.10"
     assert result["hashes"]
@@ -2150,16 +2151,16 @@ def test_get_package_hashes_without_version(murlopen, capsys):
     # Let's do it again and mess with a few things.
     # First specify python_versions.
     result = hashin.get_package_hashes(
-        package="hashin", verbose=True, python_versions=("3.5",)
+        package="hashin", verbose=True, python_versions=("3.5",), index_url="https://pypi.org/"
     )
     assert len(result["hashes"]) == 2  # instead of 3
     # Specify an unrecognized python version
     with pytest.raises(hashin.PackageError):
-        hashin.get_package_hashes(package="hashin", python_versions=("2.99999",))
+        hashin.get_package_hashes(package="hashin", python_versions=("2.99999",), index_url="https://pypi.org/")
 
     # Look for a package without any releases
     with pytest.raises(hashin.PackageError):
-        hashin.get_package_hashes(package="uggamugga")
+        hashin.get_package_hashes(package="uggamugga", index_url="https://pypi.org/")
 
 
 def test_with_extras_syntax(murlopen, tmpfile):
@@ -2193,7 +2194,7 @@ def test_with_extras_syntax(murlopen, tmpfile):
         with open(filename, "w") as f:
             f.write("")
 
-        retcode = hashin.run("hashin[stuff]", filename, "sha256")
+        retcode = hashin.run("hashin[stuff]", filename, "sha256", index_url="https://pypi.org/")
 
         assert retcode == 0
         with open(filename) as f:
@@ -2226,7 +2227,7 @@ def test_extras_syntax_edit(murlopen, tmpfile):
             f.write("hashin==0.10\n")
             f.write("    --hash=sha256:ccccc\n")
 
-        retcode = hashin.run("hashin[stuff]", filename, "sha256")
+        retcode = hashin.run("hashin[stuff]", filename, "sha256", index_url="https://pypi.org/")
 
         assert retcode == 0
         with open(filename) as f:
@@ -2260,7 +2261,7 @@ def test_add_extra_extras_syntax_edit(murlopen, tmpfile):
             f.write("hashin[stuff]==0.10\n")
             f.write("    --hash=sha256:ccccc\n")
 
-        retcode = hashin.run("hashin[extra,stuff]", filename, "sha256")
+        retcode = hashin.run("hashin[extra,stuff]", filename, "sha256", index_url="https://pypi.org/")
 
         assert retcode == 0
         with open(filename) as f:
@@ -2296,7 +2297,7 @@ def test_change_extra_extras_syntax_edit(murlopen, tmpfile):
             f.write("hashin[stuff]==0.10\n")
             f.write("    --hash=sha256:ccccc\n")
 
-        retcode = hashin.run("hashin[different]", filename, "sha256")
+        retcode = hashin.run("hashin[different]", filename, "sha256", index_url="https://pypi.org/")
 
         assert retcode == 0
         with open(filename) as f:
@@ -2330,7 +2331,7 @@ def test_remove_extra_extras_syntax_edit(murlopen, tmpfile):
             f.write("hashin[stuff]==0.10\n")
             f.write("    --hash=sha256:ccccc\n")
 
-        retcode = hashin.run("hashin", filename, "sha256")
+        retcode = hashin.run("hashin", filename, "sha256", index_url="https://pypi.org/")
 
         assert retcode == 0
         with open(filename) as f:


### PR DESCRIPTION
Adds an optional `--index-url` argument so that hashin can be used with an alternate package index.

Pip supports this behavior with the same argument. Hashin was hardcoded to point at pypi.org, so if you happened to be working with an alternate index, hashin couldn't help you.

Pip also accepts an `--extra-index-url` argument, but I'm guessing that hashin won't benefit much from supporting the same. I expect the main use case of `--index-url` to be a package or package version that only exists on the alternate index.