### PR TITLE
Be kinder if the package is a requirements file

### DIFF
--- a/hashin.py
+++ b/hashin.py
@@ -773,6 +773,23 @@ def main():
     parser = get_parser()
     args = parser.parse_args()
 
+    if (
+        args.update_all
+        and args.packages
+        and len(args.packages) == 1
+        and os.path.isfile(args.packages[0])
+        and args.packages[0].endswith(".txt")
+    ):
+        # It's totally common to make the mistake of using the `--update-all` flag
+        # and specifying the requirements file as the first argument. E.g.
+        #
+        #     $ hashin --update-all --interactive myproject/reqs.txt
+        #
+        # The user intention is clear any non-keyed flags get interpreted as a
+        # list of "packages". Let's fix that for the user.
+        args.requirements_file = args.packages[0]
+        args.packages = []
+
     if args.update_all:
         if args.packages:
             print(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -182,6 +182,36 @@ def test_packages_and_update_all(capsys, mock_get_parser):
     )
 
 
+def test_packages_and_update_all_with_requirements_file(
+    capsys, mock_get_parser, tmpfile
+):
+    with tmpfile() as filename:
+        with open(filename, "w") as f:
+            f.write("")
+
+        def mock_parse_args(*a, **k):
+            return argparse.Namespace(
+                packages=[filename],  # Note!
+                algorithm="sha256",
+                python_version="3.8",
+                verbose=False,
+                include_prereleases=False,
+                dry_run=False,
+                update_all=True,
+                interactive=False,
+                synchronous=False,
+                index_url="anything",
+            )
+
+        mock_get_parser().parse_args.side_effect = mock_parse_args
+
+        error = hashin.main()
+        assert error == 0
+        # Because the requirements file is empty, the update-all command
+        # won't find anything to query the internet about so we don't
+        # need to mock murlopen in this test.
+
+
 def test_no_packages_and_not_update_all(capsys, mock_get_parser):
     def mock_parse_args(*a, **k):
         return argparse.Namespace(


### PR DESCRIPTION
Fixes #104 

@mythmon r? 

It's a small and conservative change. I've been bitten by it so many times when running `hashin -u -i requirements/default.txt` and it essentially complaining at me when it assumes that `requirements/default.txt` is the name of a python package. 