### PR TITLE
Lock permissions down to minimum for GitHub Actions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Drop permissions to minimum for security
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Same as https://github.com/libexpat/libexpat/pull/694 (if it needs more context)