### PR TITLE
Fix function `expand_python_version` for "3.10" and upwards (fixes #184)

### DIFF
--- a/hashin.py
+++ b/hashin.py
@@ -461,7 +461,7 @@ def expand_python_version(version):
     >>> expand_python_version('3.5')
     ['3.5', 'py3', 'py2.py3', 'cp35']
     """
-    if not re.match(r"^\d\.\d$", version):
+    if not re.match(r"^\d\.\d{1,2}$", version):
         return [version]
 
     major, minor = version.split(".")

--- a/hashin.py
+++ b/hashin.py
@@ -459,7 +459,7 @@ def expand_python_version(version):
     Expand Python versions to all identifiers used on PyPI.
 
     >>> expand_python_version('3.5')
-    ['3.5', 'py3', 'py2.py3', 'cp35']
+    ['3.5', 'cp35', 'py2.py3', 'py3', 'py3.5', 'py35', 'source']
     """
     if not re.match(r"^\d\.\d{1,2}$", version):
         return [version]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2189,6 +2189,26 @@ def test_expand_python_version():
         "source",
     ]
 
+    assert sorted(hashin.expand_python_version("3.10")) == [
+        "3.10",
+        "cp310",
+        "py2.py3",
+        "py3",
+        "py3.10",
+        "py310",
+        "source",
+    ]
+
+    assert sorted(hashin.expand_python_version("3.12")) == [
+        "3.12",
+        "cp312",
+        "py2.py3",
+        "py3",
+        "py3.12",
+        "py312",
+        "source",
+    ]
+
 
 def test_get_package_hashes(murlopen):
     def mocked_get(url, **options):


### PR DESCRIPTION
Fixes #184

CC @vishnuwazoku @peterbe 