### PR TITLE
Drop dead and half-broken redirect handling from function `_download` (fixes #203)

### DIFF
--- a/hashin.py
+++ b/hashin.py
@@ -66,14 +66,7 @@ def _download(url, binary=False):
 
     # Note that urlopen will, by default, follow redirects.
     status_code = r.getcode()
-    if 301 <= status_code < 400:
-        location = r.headers.get("location", "")
-        if not location:
-            raise PackageError(
-                "No 'Location' header on {0} ({1})".format(url, status_code)
-            )
-        return _download(location)
-    elif status_code == 404:
+    if status_code == 404:
         raise PackageNotFoundError(url)
     elif status_code != 200:
         raise PackageError("Download error. {0} on {1}".format(status_code, url))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1269,13 +1269,6 @@ def test_run_interactive_case_redirect(murlopen, tmpfile, capsys):
         # different case, it's also spelled totally differently.
         if url == "https://pypi.org/pypi/Hash-in/json":
             return _Response(
-                "",
-                status_code=301,
-                headers={"location": "https://pypi.org/pypi/hashin/json"},
-            )
-
-        if url == "https://pypi.org/pypi/hashin/json":
-            return _Response(
                 {
                     "info": {"version": "0.10", "name": "hashin"},
                     "releases": {
@@ -1699,19 +1692,10 @@ def test_run_update_all(murlopen, tmpfile):
     requirements file, and check with pypi.org if there's a new version."""
 
     def mocked_get(url, **options):
-        if url == "https://pypi.org/pypi/HAShin/json":
-            return _Response(
-                "",
-                status_code=301,
-                headers={"location": "https://pypi.org/pypi/hashin/json"},
-            )
-        elif url == "https://pypi.org/pypi/hashIN/json":
-            return _Response(
-                "",
-                status_code=301,
-                headers={"location": "https://pypi.org/pypi/hashin/json"},
-            )
-        elif url == "https://pypi.org/pypi/hashin/json":
+        if url in (
+            "https://pypi.org/pypi/HAShin/json",
+            "https://pypi.org/pypi/hashIN/json",
+        ):
             return _Response(
                 {
                     "info": {"version": "0.11", "name": "hashin"},


### PR DESCRIPTION
Apparently `urllib.request.urlopen` is already following redirects for us, and `return _download(location)` was (1) not forwarding flag `binary` and (2) not supporting non-absolute URIs without a scheme.

CC @peterbe 