### PR TITLE
[rfc] Resolve dependency on pip-api

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     url="https://github.com/peterbe/hashin",
     include_package_data=True,
     python_requires=">=3.9",
-    install_requires=["packaging", "pip-api"],
+    install_requires=["packaging", "pip"],
     tests_require=["pytest"],
     setup_requires=["pytest-runner"],
     extras_require={"dev": ["tox", "twine"]},


### PR DESCRIPTION
Hi @peterbe,

when trying to package hashin for Gentoo, I noticed its dependency on pip-api that is [not packaged in Gentoo, Debian or Ubuntu](https://repology.org/project/python%3Apip-api/versions). The latest release of pip-api is 11 months old, it is using [its own copy of `packaging`](https://github.com/search?q=repo%3Adi%2Fpip-api+_vendor+path%3Apip_api%2F*.py&type=code) and it does very little over plain `pip` for hashin as of today. How do you feel about resolving use of pip-api altogether?

My approach below is inspired by these three files of pip-api:
- https://github.com/di/pip-api/blob/master/pip_api/_call.py
- https://github.com/di/pip-api/blob/master/pip_api/_hash.py
- https://github.com/di/pip-api/blob/master/pip_api/_version.py

What do you think?

Best, Sebastian
